### PR TITLE
scss対応・issue詳細表示切替

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-vue": "^6.2.2",
     "lint-staged": "^9.5.0",
+    "node-sass": "^4.14.1",
+    "sass-loader": "^8.0.2",
     "typescript": "~3.8.3",
     "vue-template-compiler": "^2.6.11"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,14 +12,7 @@
           option(disabled, selected) 選択してね
           option(v-for="lang in languages") {{lang}}
     section#issues
-      aside(v-for="issue in issues")
-        h3
-          a(:href='issue.html_url', target='_blank', rel="noopener noreferrer") [外部リンク]{{issue.title}}
-        p
-          label(v-for='label in issue.labels', :style="{backgroundColor: '#'+label.color}") {{label.name}}
-          | created at {{issue.created_at}}
-        hr
-        div(v-html="renderMD(issue.body)")
+      Issues(v-for="issue in issues", :key="issue.title", :data="issue")
     section
       button(@click="paginate", v-if="issues.length") さらに読み込む
 </template>
@@ -27,19 +20,8 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import languages from '@/languages'
+import Issues from '@/components/Issues.vue'
 import axios from 'axios'
-import { Marked, escape, Renderer } from 'marked-ts'
-
-Marked.setOptions({
-  renderer: new Renderer(),
-  gfm: true,
-  tables: true,
-  breaks: false,
-  pedantic: false,
-  sanitize: false,
-  smartLists: true,
-  smartypants: false
-})
 
 interface GithubLabel {
   color: string;
@@ -83,7 +65,12 @@ class Label {
   }
 }
 
-@Component
+@Component({
+  components: {
+    Issues
+  }
+})
+
 export default class App extends Vue {
   public page=1;
   public languages: Array<string> = languages;
@@ -100,10 +87,6 @@ export default class App extends Vue {
   public paginate (): void {
     this.page++
     this.getIssues()
-  }
-
-  public renderMD (markdown: string): string {
-    return Marked.parse(escape(markdown))
   }
 
   public async getIssues (): Promise<void> {
@@ -139,8 +122,8 @@ export default class App extends Vue {
   }
 }
 </script>
-<style>
-  #issues aside{
+<style lang="scss">
+  #issues aside {
     width: 60%;
   }
   p label {

--- a/src/components/Issues.vue
+++ b/src/components/Issues.vue
@@ -1,0 +1,66 @@
+<template lang="pug">
+  aside
+    div.summary(:class="{ active: flag }", @click="showToggle")
+      h3
+        a(:href='data.html_url', target='_blank', rel="noopener noreferrer") [外部リンク]{{data.title}}
+      p
+        label(v-for='label in data.labels', :style="{backgroundColor: '#'+label.color}") {{label.name}}
+        | created at {{data.created_at}}
+    div.description(v-if="flag")
+      hr
+      div(v-html="renderMD(data.body)")
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import { Marked, escape, Renderer } from 'marked-ts'
+
+Marked.setOptions({
+  renderer: new Renderer(),
+  gfm: true,
+  tables: true,
+  breaks: false,
+  pedantic: false,
+  sanitize: false,
+  smartLists: true,
+  smartypants: false
+})
+
+@Component({
+  props: {
+    data: Object
+  }
+})
+
+export default class Issues extends Vue {
+  flag = false
+
+  public renderMD (markdown: string): string {
+    return Marked.parse(escape(markdown))
+  }
+
+  public showToggle (): void {
+    this.flag = !this.flag
+  }
+}
+</script>
+<style lang="scss">
+  .summary {
+    position: relative;
+    cursor: pointer;
+
+    &::after {
+      content: "\025bc";
+      font-size: 16px;
+      position: absolute;
+      right: 0;
+      top: calc(50% - 8px);
+    }
+
+    &.active {
+      &::after {
+        content: "\025b2";
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
# 概要
* scssで記載できるように、対応しました。
* issue表示部分をcomponentに分離し、descriptionを表示切替できるようにしました。

## 留意点等
lets-contribute\src\components\Issues.vue 36行目
flag部分なのですが、ts様にbooleanで定義しようとしたら怒られました！
定義の仕方が悪かったのかもしれないのです。解決法ご存じでしたら教えていただきたいです！

ご確認よろしくお願いいたします！