### PR TITLE
Issue Label: コントラストによって文字色を変更

### DIFF
--- a/src/components/Issues.vue
+++ b/src/components/Issues.vue
@@ -10,7 +10,7 @@
           | {{data.title}}
           ExternalLinkIcon
       p
-        label(v-for='label in data.labels', :style="{backgroundColor: '#'+label.color}") {{label.name}}
+        label(v-for='label in data.labels', :style="getLabelStyle(label.color)") {{label.name}}
         | created at {{data.created_at}}
     hr
     div.description(:class='{active:open}')
@@ -23,6 +23,7 @@ import { Prop, Component, Vue } from 'vue-property-decorator'
 import { Marked, escape, Renderer } from 'marked-ts'
 import { GithubIssue } from '@/@types/Github'
 import ExternalLinkIcon from '@/components/ExternalLinkIcon.vue'
+import { getContrastYIQ } from '@/utils/color.ts'
 Marked.setOptions({
   renderer: new Renderer(),
   gfm: true,
@@ -60,6 +61,13 @@ export default class Issues extends Vue {
 
   public showToggle (): void {
     this.open = !this.open
+  }
+
+  public getLabelStyle (color: string): {backgroundColor: string; color: string} {
+    return {
+      backgroundColor: `#${color}`,
+      color: getContrastYIQ(color)
+    }
   }
 }
 </script>

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,7 @@
+export function getContrastYIQ (hex: string): 'black'|'white' {
+  const r = parseInt(hex.substr(0, 2), 16)
+  const g = parseInt(hex.substr(2, 2), 16)
+  const b = parseInt(hex.substr(4, 2), 16)
+  const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000
+  return (yiq >= 128) ? 'black' : 'white'
+}


### PR DESCRIPTION
close #13 

Issue Label の背景色によって文字色を切り替えるように変更

一般的なチェック手法
https://24ways.org/2010/calculating-color-contrast/

GitHub 公式のチェック方法
https://github.githubassets.com/assets/github-bootstrap-8adc1822.js
`return+((299*(t>>16&255)+587*(t>>8&255)+114*(255&t))/1e3/255).toFixed(2)} `

これらに合わせて文字色を適用するようにした

## スクショ

### after
<img width="394" alt="スクリーンショット 2020-05-25 19 04 48" src="https://user-images.githubusercontent.com/8909592/82803729-00a3da80-9ebc-11ea-89d9-ccb5ca55eba8.png">

<img width="219" alt="スクリーンショット 2020-05-25 19 04 51" src="https://user-images.githubusercontent.com/8909592/82803724-000b4400-9ebc-11ea-9835-c87d7d4caae7.png">

### before

<img width="265" alt="スクリーンショット 2020-05-25 19 15 02" src="https://user-images.githubusercontent.com/8909592/82803796-1a452200-9ebc-11ea-8c22-ef7f749d1eed.png">
<img width="285" alt="スクリーンショット 2020-05-25 19 14 57" src="https://user-images.githubusercontent.com/8909592/82803800-1b764f00-9ebc-11ea-8929-d2c111a2c07b.png">
