### PR TITLE
タイトル位置調整・タグのデザイン修正

### DIFF
--- a/src/components/Issues.vue
+++ b/src/components/Issues.vue
@@ -9,7 +9,7 @@
         a(:href='data.html_url', target='_blank', rel="noopener noreferrer")
           | {{data.title}}
           ExternalLinkIcon
-      p
+      p.tags
         label(v-for='label in data.labels', :style="getLabelStyle(label.color)") {{label.name}}
         | created at {{data.created_at}}
     hr
@@ -75,6 +75,9 @@ export default class Issues extends Vue {
   .summary {
     position: relative;
     cursor: pointer;
+    .tags {
+      line-height: 2;
+    }
   }
   .description {
     position: relative;

--- a/src/components/Logo.vue
+++ b/src/components/Logo.vue
@@ -30,14 +30,22 @@ export default class Logo extends Vue {
     overflow: hidden;
     & h1 {
       font-size: 64px;
-      margin: 0 0 30px 0;
+      margin: 0;
+      width: 100%;
     }
     & .inner {
       margin: 60px;
 
+      display: flex;
+      justify-content: center;
+      align-content: center;
+      flex-wrap: wrap;
       color: black;
       background: rgba(255,255,255, 0.9);
       min-height: 240px;
+      h2 {
+        width: 100%;
+      }
     }
     .grasses {
       position: absolute;


### PR DESCRIPTION
・メインビューのタイトルを中央に寄せました
・issueのタグが複数行にわたる際に、↓のようにタグが被ってしまうのを解消しました
![image](https://user-images.githubusercontent.com/34328392/82823917-6061ac00-9ee3-11ea-8202-9439a30d1605.png)
