### PR TITLE
v-forに対するkeyの重複を修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
           i(:class="`devicon-${language.icon}-plain colored`", v-if="language.icon")
           | {{language.name}}
     section#issues
-      Issues(v-for="issue in issues", :key="issue.title", :data="issue")
+      Issues(v-for="issue in issues", :key="issue.url.split('/repos/')[1]", :data="issue")
     section
       button(@click="paginate", v-if="issues.length") さらに読み込む
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
           i(:class="`devicon-${language.icon}-plain colored`", v-if="language.icon")
           | {{language.name}}
     section#issues
-      Issues(v-for="issue in issues", :key="issue.url.split('/repos/')[1]", :data="issue")
+      Issues(v-for="issue in issues", :key="issue.id", :data="issue")
     section
       button(@click="paginate", v-if="issues.length") さらに読み込む
 </template>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24470756/82832098-26010a80-9ef5-11ea-89a4-7f8b65926794.png)

`issues`の中に重複した`issue.title`がある場合に、さらに読み込むを押したときに確認できました。

重複しないであろう`issue.url`に変更しました。