### PR TITLE
Logo.vue のフォントサイズの修正と、 margin の修正 #22

### DIFF
--- a/src/components/Logo.vue
+++ b/src/components/Logo.vue
@@ -32,10 +32,12 @@ export default class Logo extends Vue {
       font-size: 64px;
       margin: 0;
       width: 100%;
+      @media screen and ( max-width: 750px ) {
+        font-size: 32px
+      }
     }
     & .inner {
       margin: 60px;
-
       display: flex;
       justify-content: center;
       align-content: center;
@@ -43,8 +45,14 @@ export default class Logo extends Vue {
       color: black;
       background: rgba(255,255,255, 0.9);
       min-height: 240px;
+      @media screen and ( max-width: 750px ) {
+        margin: 30px
+      }
       h2 {
         width: 100%;
+        @media screen and ( max-width: 750px ) {
+          font-size: 20px
+        }
       }
     }
     .grasses {


### PR DESCRIPTION
Logo.vue で、スマートフォンなどの特定端末幅のものから閲覧すると、フォントサイズの大きさと、 margin 値によりはみ出してしまうので、値を小さくしました。

該当issue
#22 