### PR TITLE
[#24]issueコンポーネントのword-break設定

### DIFF
--- a/src/components/Issues.vue
+++ b/src/components/Issues.vue
@@ -72,6 +72,9 @@ export default class Issues extends Vue {
 }
 </script>
 <style lang="scss">
+  aside {
+    word-break: break-all;
+  }
   .summary {
     position: relative;
     cursor: pointer;


### PR DESCRIPTION
This commit fixes #24

---

Issues.vue内でリポジトリ名、タイトル、タグ、内容が連続する英数字の場合に要素外にはみ出すバグを修正

before
![image](https://user-images.githubusercontent.com/54521076/107604394-65ce7480-6c73-11eb-815e-1592eef3be54.png)

after
![image](https://user-images.githubusercontent.com/54521076/107604403-6a932880-6c73-11eb-99aa-0faec4568947.png)
